### PR TITLE
Update for change to kafka-connect-couchbase build.

### DIFF
--- a/kafka-connect-couchbase/fast-data-dev-couchbase-connector/Dockerfile
+++ b/kafka-connect-couchbase/fast-data-dev-couchbase-connector/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache git openjdk8 maven \
     && git clone https://github.com/couchbase/kafka-connect-couchbase.git \
     && cd kafka-connect-couchbase \
     && mvn package \
-    && cp target/kafka-connect-couchbase-*-package/share/java/kafka-connect-couchbase/* /connectors \
+    && cp target/kafka-connect-couchbase-*.jar /connectors \
     && cd / && rm -rf kafka-connect-couchbase \
     && apk del --no-cache git maven
 


### PR DESCRIPTION
The upstream build script changed a while back; the Couchbase connector
is packaged as an uber-jar immediately under the `target` directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-connectors-tests/6)
<!-- Reviewable:end -->
